### PR TITLE
Possibility to use RenderScript

### DIFF
--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
@@ -67,7 +67,7 @@ class BlurDialogEngine {
     /**
      * Default use of RenderScript.
      */
-    public static final boolean DEFAULT_USE_RENDERSCRIPT = false;
+    static final boolean DEFAULT_USE_RENDERSCRIPT = false;
 
     /**
      * Log cat
@@ -374,11 +374,12 @@ class BlurDialogEngine {
             String blurTime = (System.currentTimeMillis() - startMs) + " ms";
 
             //display information in LogCat
+            Log.d(TAG, "Blur method : " + (mUseRenderScript ? "RenderScript" : "FastBlur"));
             Log.d(TAG, "Radius : " + mBlurRadius);
             Log.d(TAG, "Down Scale Factor : " + mDownScaleFactor);
             Log.d(TAG, "Blurred achieved in : " + blurTime);
             Log.d(TAG, "Allocation : " + bkg.getRowBytes() + "ko (screen capture) + "
-                    + overlay.getRowBytes() + "ko (FastBlur)");
+                    + overlay.getRowBytes() + "ko (blurred bitmap)");
             //display blurring time directly on screen
             Rect bounds = new Rect();
             Canvas canvas1 = new Canvas(overlay);

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
@@ -65,6 +65,11 @@ class BlurDialogEngine {
     static final boolean DEFAULT_ACTION_BAR_BLUR = false;
 
     /**
+     * Default use of RenderScript.
+     */
+    public static final boolean DEFAULT_USE_RENDERSCRIPT = false;
+
+    /**
      * Log cat
      */
     private static final String TAG = BlurDialogEngine.class.getSimpleName();
@@ -121,6 +126,11 @@ class BlurDialogEngine {
      * Boolean used to know if the actionBar should be blurred.
      */
     private boolean mBlurredActionBar;
+
+    /**
+     * Boolean used to know if RenderScript should be used
+     */
+    private boolean mUseRenderScript;
 
 
     /**
@@ -227,6 +237,19 @@ class BlurDialogEngine {
         } else {
             mBlurRadius = 0;
         }
+    }
+
+    /**
+     * Set use of RenderScript
+     * <p/>
+     * By default RenderScript is set to
+     * {@link BlurDialogEngine#DEFAULT_USE_RENDERSCRIPT}
+     *
+     * @param useRenderScript use of RenderScript
+     */
+
+    public void setUseRenderScript(boolean useRenderScript) {
+        mUseRenderScript = useRenderScript;
     }
 
     /**
@@ -345,7 +368,7 @@ class BlurDialogEngine {
         canvas.drawBitmap(bkg, srcRect, destRect, paint);
 
         //apply fast blur on overlay
-        overlay = FastBlurHelper.doBlur(overlay, mBlurRadius, true);
+        overlay = FastBlurHelper.doBlur(overlay, mBlurRadius, true, mUseRenderScript, mHoldingActivity);
 
         if (mDebugEnable) {
             String blurTime = (System.currentTimeMillis() - startMs) + " ms";

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogFragment.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogFragment.java
@@ -1,10 +1,8 @@
 package fr.tvbarthel.lib.blurdialogfragment;
 
-import android.annotation.TargetApi;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.view.WindowManager;
@@ -14,7 +12,6 @@ import android.view.WindowManager;
  * <p/>
  * All the screen behind the dialog will be blurred except the action bar.
  */
-@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public abstract class BlurDialogFragment extends DialogFragment {
 
     /**
@@ -53,6 +50,8 @@ public abstract class BlurDialogFragment extends DialogFragment {
             throw new IllegalArgumentException("Down scale must be strictly greater than 1.0. Found : " + factor);
         }
         mBlurEngine.setDownScaleFactor(factor);
+
+        mBlurEngine.setUseRenderScript(isRenderScriptEnable());
 
         mBlurEngine.debug(isDebugEnable());
 
@@ -185,5 +184,18 @@ public abstract class BlurDialogFragment extends DialogFragment {
      */
     protected boolean isActionBarBlurred() {
         return BlurDialogEngine.DEFAULT_ACTION_BAR_BLUR;
+    }
+
+    /**
+     * For inheritance purpose.
+     * <p/>
+     * Enable or disable RenderScript.
+     * <p/>
+     * Disable by default.
+     *
+     * @return true to enable RenderScript.
+     */
+    protected boolean isRenderScriptEnable() {
+        return BlurDialogEngine.DEFAULT_USE_RENDERSCRIPT;
     }
 }

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
@@ -44,7 +44,8 @@ final class FastBlurHelper {
      * @return blurred bitmap
      */
     @SuppressLint("NewApi")
-    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap, boolean useRenderScript, Context context) {
+    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap,
+                                boolean useRenderScript, Context context) {
 
         if (radius < 1) {
             return (null);
@@ -52,7 +53,8 @@ final class FastBlurHelper {
 
         Bitmap bitmap;
         if (canReuseInBitmap || (useRenderScript && sentBitmap.getConfig() == Bitmap.Config.RGB_565)) {
-            // if RenderScript is used and bitmap is in RGB_565, it will necessarily be copied when converting to ARGB_8888
+            // if RenderScript is used and bitmap is in RGB_565, it will
+            // necessarily be copied when converting to ARGB_8888
             bitmap = sentBitmap;
         } else {
             bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
@@ -61,7 +63,8 @@ final class FastBlurHelper {
         if (Build.VERSION.SDK_INT > 16 && useRenderScript) {
             if (bitmap.getConfig() == Bitmap.Config.RGB_565) {
                 // RenderScript hates RGB_565 so we convert it to ARGB_8888
-                // (see http://stackoverflow.com/questions/21563299/defect-of-image-with-scriptintrinsicblur-from-support-library)
+                // (see http://stackoverflow.com/questions/21563299/
+                // defect-of-image-with-scriptintrinsicblur-from-support-library)
                 bitmap = convertRGB565toARGB888(bitmap);
             }
 

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
@@ -1,6 +1,13 @@
 package fr.tvbarthel.lib.blurdialogfragment;
 
+import android.annotation.SuppressLint;
+import android.content.Context;
 import android.graphics.Bitmap;
+import android.os.Build;
+import android.renderscript.Allocation;
+import android.renderscript.Element;
+import android.renderscript.RenderScript;
+import android.renderscript.ScriptIntrinsicBlur;
 
 /**
  * Helper used to apply Fast blur algorithm on bitmap.
@@ -22,7 +29,39 @@ final class FastBlurHelper {
      * @param canReuseInBitmap true if bitmap must be reused without blur
      * @return blurred bitmap
      */
-    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap) {
+    @SuppressLint("NewApi")
+    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap, boolean useRenderScript, Context context) {
+
+        if (radius < 1) {
+            return (null);
+        }
+
+        Bitmap bitmap;
+        if (canReuseInBitmap || (useRenderScript && sentBitmap.getConfig() == Bitmap.Config.RGB_565)) {
+            // if RenderScript is used and bitmap is in RGB_565, it will necessarily be copied when converting to ARGB_8888
+            bitmap = sentBitmap;
+        } else {
+            bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
+        }
+
+        if (Build.VERSION.SDK_INT > 16 && useRenderScript) {
+            if (bitmap.getConfig() == Bitmap.Config.RGB_565) {
+                // RenderScript hates RGB_565 so we convert it to ARGB_8888
+                // (see http://stackoverflow.com/questions/21563299/defect-of-image-with-scriptintrinsicblur-from-support-library)
+                bitmap = convertRGB565toARGB888(bitmap);
+            }
+
+            final RenderScript rs = RenderScript.create(context);
+            final Allocation input = Allocation.createFromBitmap(rs, bitmap, Allocation.MipmapControl.MIPMAP_NONE,
+                    Allocation.USAGE_SCRIPT);
+            final Allocation output = Allocation.createTyped(rs, input.getType());
+            final ScriptIntrinsicBlur script = ScriptIntrinsicBlur.create(rs, Element.U8_4(rs));
+            script.setRadius(radius);
+            script.setInput(input);
+            script.forEach(output);
+            output.copyTo(bitmap);
+            return bitmap;
+        }
 
         // Stack Blur v1.0 from
         // http://www.quasimondo.com/StackBlurForCanvas/StackBlurDemo.html
@@ -51,17 +90,6 @@ final class FastBlurHelper {
         // the following line:
         //
         // Stack Blur Algorithm by Mario Klingemann <mario@quasimondo.com>
-
-        Bitmap bitmap;
-        if (canReuseInBitmap) {
-            bitmap = sentBitmap;
-        } else {
-            bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
-        }
-
-        if (radius < 1) {
-            return (null);
-        }
 
         int w = bitmap.getWidth();
         int h = bitmap.getHeight();
@@ -255,5 +283,9 @@ final class FastBlurHelper {
         bitmap.setPixels(pix, 0, w, 0, 0, w, h);
 
         return (bitmap);
+    }
+
+    private static Bitmap convertRGB565toARGB888(Bitmap bitmap) {
+        return bitmap.copy(Bitmap.Config.ARGB_8888, true);
     }
 }

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
@@ -29,6 +29,20 @@ final class FastBlurHelper {
      * @param canReuseInBitmap true if bitmap must be reused without blur
      * @return blurred bitmap
      */
+    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap) {
+        return doBlur(sentBitmap, radius, canReuseInBitmap, false, null);
+    }
+
+    /**
+     * blur a given bitmap
+     *
+     * @param sentBitmap       bitmap to blur
+     * @param radius           blur radius
+     * @param canReuseInBitmap true if bitmap must be reused without blur
+     * @param useRenderScript  true if should use RenderScript
+     * @param context          used by RenderScript, can be null if RenderScript disabled
+     * @return blurred bitmap
+     */
     @SuppressLint("NewApi")
     public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap, boolean useRenderScript, Context context) {
 

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/SupportBlurDialogFragment.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/SupportBlurDialogFragment.java
@@ -52,6 +52,8 @@ public abstract class SupportBlurDialogFragment extends DialogFragment {
         }
         mBlurEngine.setDownScaleFactor(factor);
 
+        mBlurEngine.setUseRenderScript(getUseRenderScript());
+
         mBlurEngine.debug(isDebugEnable());
 
         mBlurEngine.setBlurActionBar(isActionBarBlurred());
@@ -183,4 +185,18 @@ public abstract class SupportBlurDialogFragment extends DialogFragment {
     protected boolean isActionBarBlurred() {
         return BlurDialogEngine.DEFAULT_ACTION_BAR_BLUR;
     }
+
+    /**
+     * For inheritance purpose.
+     * <p/>
+     * Enable or disable RenderScript.
+     * <p/>
+     * Disable by default.
+     *
+     * @return true to enable RenderScript.
+     */
+    protected boolean getUseRenderScript() {
+        return BlurDialogEngine.DEFAULT_USE_RENDERSCRIPT;
+    }
+
 }

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/SupportBlurDialogFragment.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/SupportBlurDialogFragment.java
@@ -52,7 +52,7 @@ public abstract class SupportBlurDialogFragment extends DialogFragment {
         }
         mBlurEngine.setDownScaleFactor(factor);
 
-        mBlurEngine.setUseRenderScript(getUseRenderScript());
+        mBlurEngine.setUseRenderScript(isRenderScriptEnable());
 
         mBlurEngine.debug(isDebugEnable());
 
@@ -195,7 +195,7 @@ public abstract class SupportBlurDialogFragment extends DialogFragment {
      *
      * @return true to enable RenderScript.
      */
-    protected boolean getUseRenderScript() {
+    protected boolean isRenderScriptEnable() {
         return BlurDialogEngine.DEFAULT_USE_RENDERSCRIPT;
     }
 

--- a/sample/src/main/java/fr/tvbarthel/lib/blurdialogfragment/sample/SampleActionBarActivity.java
+++ b/sample/src/main/java/fr/tvbarthel/lib/blurdialogfragment/sample/SampleActionBarActivity.java
@@ -58,6 +58,11 @@ public class SampleActionBarActivity extends ActionBarActivity implements View.O
      */
     private CheckBox mBlurredActionBar;
 
+    /**
+     * Checkbox used to enable / disable use of RenderScript
+     */
+    private CheckBox mUseRenderScript;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -71,6 +76,7 @@ public class SampleActionBarActivity extends ActionBarActivity implements View.O
         mDebugMode = ((CheckBox) findViewById(R.id.debugMode));
         mDimmingEnable = ((CheckBox) findViewById(R.id.dimmingEnable));
         mBlurredActionBar = ((CheckBox) findViewById(R.id.blur_actionbar_enable));
+        mUseRenderScript = ((CheckBox) findViewById(R.id.userendercript));
 
         setUpView();
     }
@@ -105,7 +111,8 @@ public class SampleActionBarActivity extends ActionBarActivity implements View.O
                         mDownScaleFactorSeekbar.getProgress(),
                         mDimmingEnable.isChecked(),
                         mDebugMode.isChecked(),
-                        mBlurredActionBar.isChecked()
+                        mBlurredActionBar.isChecked(),
+                        mUseRenderScript.isChecked()
                 );
                 fragment.show(getSupportFragmentManager(), "blur_sample");
                 break;

--- a/sample/src/main/java/fr/tvbarthel/lib/blurdialogfragment/sample/SampleSupportDialogFragment.java
+++ b/sample/src/main/java/fr/tvbarthel/lib/blurdialogfragment/sample/SampleSupportDialogFragment.java
@@ -42,11 +42,17 @@ public class SampleSupportDialogFragment extends SupportBlurDialogFragment {
      */
     private static final String BUNDLE_KEY_BLURRED_ACTION_BAR = "bundle_key_blurred_action_bar";
 
+    /**
+     * Bundle key used for RenderScript
+     */
+    private static final String BUNDLE_KEY_USE_RENDERSCRIPT = "bundle_key_use_renderscript";
+
     private int mRadius;
     private float mDownScaleFactor;
     private boolean mDimming;
     private boolean mDebug;
     private boolean mBlurredActionBar;
+    private boolean mUseRenderScript;
 
     /**
      * Retrieve a new instance of the sample fragment.
@@ -56,13 +62,15 @@ public class SampleSupportDialogFragment extends SupportBlurDialogFragment {
      * @param dimming           dimming effect.
      * @param debug             debug policy.
      * @param mBlurredActionBar blur affect on actionBar policy.
+     * @param useRenderScript   use of RenderScript
      * @return well instantiated fragment.
      */
     public static SampleSupportDialogFragment newInstance(int radius,
                                                           float downScaleFactor,
                                                           boolean dimming,
                                                           boolean debug,
-                                                          boolean mBlurredActionBar) {
+                                                          boolean mBlurredActionBar,
+                                                          boolean useRenderScript) {
         SampleSupportDialogFragment fragment = new SampleSupportDialogFragment();
         Bundle args = new Bundle();
         args.putInt(
@@ -85,6 +93,10 @@ public class SampleSupportDialogFragment extends SupportBlurDialogFragment {
                 BUNDLE_KEY_BLURRED_ACTION_BAR,
                 mBlurredActionBar
         );
+        args.putBoolean(
+                BUNDLE_KEY_USE_RENDERSCRIPT,
+                useRenderScript
+        );
 
         fragment.setArguments(args);
 
@@ -101,6 +113,7 @@ public class SampleSupportDialogFragment extends SupportBlurDialogFragment {
         mDimming = args.getBoolean(BUNDLE_KEY_DIMMING);
         mDebug = args.getBoolean(BUNDLE_KEY_DEBUG);
         mBlurredActionBar = args.getBoolean(BUNDLE_KEY_BLURRED_ACTION_BAR);
+        mUseRenderScript = args.getBoolean(BUNDLE_KEY_USE_RENDERSCRIPT);
     }
 
     @Override
@@ -143,5 +156,10 @@ public class SampleSupportDialogFragment extends SupportBlurDialogFragment {
     @Override
     protected int getBlurRadius() {
         return mRadius;
+    }
+
+    @Override
+    protected boolean getUseRenderScript() {
+        return mUseRenderScript;
     }
 }

--- a/sample/src/main/java/fr/tvbarthel/lib/blurdialogfragment/sample/SampleSupportDialogFragment.java
+++ b/sample/src/main/java/fr/tvbarthel/lib/blurdialogfragment/sample/SampleSupportDialogFragment.java
@@ -159,7 +159,7 @@ public class SampleSupportDialogFragment extends SupportBlurDialogFragment {
     }
 
     @Override
-    protected boolean getUseRenderScript() {
+    protected boolean isRenderScriptEnable() {
         return mUseRenderScript;
     }
 }

--- a/sample/src/main/res/layout/activity_sample.xml
+++ b/sample/src/main/res/layout/activity_sample.xml
@@ -65,6 +65,13 @@
             <CheckBox
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:text="@string/activity_sample_blur_userendercript"
+                android:textColor="@color/secondary_text_default_material_light"
+                android:id="@+id/userendercript" />
+
+            <CheckBox
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:text="@string/activity_sample_actionbar_blurred"
                 android:textColor="@color/secondary_text_default_material_light"
                 android:id="@+id/blur_actionbar_enable" />

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -11,5 +11,6 @@
     <string name="activity_sample_blur_debug">Debug enable</string>
     <string name="activity_sample_blur_dimming">Dimming enable</string>
     <string name="activity_sample_actionbar_blurred">Apply blur effect on action bar</string>
+    <string name="activity_sample_blur_userendercript">Use RenderScript if possible</string>
 
 </resources>


### PR DESCRIPTION
This PR adds the possibility of using RenderScript for blurring. Sample has been updated with a checkbox to  enable RenderScript.
 * By default, the library does not use RenderScript.
 * API is backward compatible with identical behaviour.
 * I chose not to use RenderScript retrocompatibilty to API level >= 8, as it forces the developer of the final app to modify his build.gradle file (see http://android-developers.blogspot.fr/2013/09/renderscript-in-android-support-library.html), but it's up to you to change that if you want ;)