### PR TITLE
[BlurEngine] fix delayed blur due to pre-draw registration

### DIFF
--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
@@ -135,7 +135,6 @@ public class BlurDialogEngine {
      */
     private boolean mUseRenderScript;
 
-
     /**
      * Constructor.
      *
@@ -155,7 +154,6 @@ public class BlurDialogEngine {
         mHoldingActivity = activity;
     }
 
-
     /**
      * Resume the engine.
      *
@@ -163,16 +161,26 @@ public class BlurDialogEngine {
      */
     public void onResume(boolean retainedInstance) {
         if (mBlurredBackgroundView == null || retainedInstance) {
-            mHoldingActivity.getWindow().getDecorView().getViewTreeObserver().addOnPreDrawListener(
-                new ViewTreeObserver.OnPreDrawListener() {
-                    @Override
-                    public boolean onPreDraw() {
-                        mHoldingActivity.getWindow().getDecorView().getViewTreeObserver().removeOnPreDrawListener(this);
-                        mBluringTask = new BlurAsyncTask();
-                        mBluringTask.execute();
-                        return false;
+            if (mHoldingActivity.getWindow().getDecorView().isShown()) {
+                mBluringTask = new BlurAsyncTask();
+                mBluringTask.execute();
+            } else {
+                mHoldingActivity.getWindow().getDecorView().getViewTreeObserver().addOnPreDrawListener(
+                    new ViewTreeObserver.OnPreDrawListener() {
+                        @Override
+                        public boolean onPreDraw() {
+                            // dialog can have been closed before being drawn
+                            if (mHoldingActivity != null) {
+                                mHoldingActivity.getWindow().getDecorView()
+                                    .getViewTreeObserver().removeOnPreDrawListener(this);
+                                mBluringTask = new BlurAsyncTask();
+                                mBluringTask.execute();
+                            }
+                            return true;
+                        }
                     }
-                });
+                );
+            }
         }
     }
 

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogFragment.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogFragment.java
@@ -98,7 +98,6 @@ public abstract class BlurDialogFragment extends DialogFragment {
         mBlurEngine.onResume(getRetainInstance());
     }
 
-
     @Override
     public void onDismiss(DialogInterface dialog) {
         super.onDismiss(dialog);


### PR DESCRIPTION
Blame myself on this.

When requesting a blur, there no certitude that a new draw pass will be performed for the holding activity decor view. Therefore registering a onPreDrawListener was completly silly if the holding activity decor view was already displayed. 

This was leading to several crashes due to registered onPreDrawListener triggered only once the dialog fragment was destroyed. HoldingActivity was at this time null and an NPE was fired.

#62 

A onPreDrawListener is still needed to handle a configuration change. In fact, dialogs fragments are attached again before activity UI is drawn. That's why we have to wait onPreDraw to ensure that blurred won't be performed on black pixels. But instead on registering the onPreDrawListener every times, we check now that the decor view isn't already shown.  If it's the case, we directly launch the blur process.

Hope I won't release new critical bugs like this in the futur...


