### PR TITLE
[Bluring] Remove the "canReuseBitmap" param

### DIFF
--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
@@ -356,9 +356,9 @@ public class BlurDialogEngine {
         final Bitmap blurredBackground;
         //apply fast blur on overlay
         if (mUseRenderScript) {
-            blurredBackground = RenderScriptBlurHelper.doBlur(bkg, mBlurRadius, true, mHoldingActivity);
+            blurredBackground = RenderScriptBlurHelper.doBlur(bkg, mBlurRadius, mHoldingActivity);
         } else {
-            blurredBackground = FastBlurHelper.doBlur(bkg, mBlurRadius, true);
+            blurredBackground = FastBlurHelper.doBlur(bkg, mBlurRadius);
         }
 
         if (blurredBackground == null) {

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/FastBlurHelper.java
@@ -20,25 +20,13 @@ final class FastBlurHelper {
      *
      * @param sentBitmap       bitmap to blur
      * @param radius           blur radius
-     * @param canReuseInBitmap true if bitmap must be reused without blur
      * @return blurred bitmap
      */
     @SuppressLint("NewApi")
-    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap) {
-
+    public static Bitmap doBlur(Bitmap sentBitmap, int radius) {
         if (radius < 1) {
             return (null);
         }
-
-        Bitmap bitmap;
-        if (canReuseInBitmap || (sentBitmap.getConfig() == Bitmap.Config.RGB_565)) {
-            // if RenderScript is used and bitmap is in RGB_565, it will
-            // necessarily be copied when converting to ARGB_8888
-            bitmap = sentBitmap;
-        } else {
-            bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
-        }
-
 
         // Stack Blur v1.0 from
         // http://www.quasimondo.com/StackBlurForCanvas/StackBlurDemo.html
@@ -71,11 +59,11 @@ final class FastBlurHelper {
         //
         // Stack Blur Algorithm by Mario Klingemann <mario@quasimondo.com>
 
-        int w = bitmap.getWidth();
-        int h = bitmap.getHeight();
+        int w = sentBitmap.getWidth();
+        int h = sentBitmap.getHeight();
 
         int[] pix = new int[w * h];
-        bitmap.getPixels(pix, 0, w, 0, 0, w, h);
+        sentBitmap.getPixels(pix, 0, w, 0, 0, w, h);
 
         int wm = w - 1;
         int hm = h - 1;
@@ -260,8 +248,8 @@ final class FastBlurHelper {
             }
         }
 
-        bitmap.setPixels(pix, 0, w, 0, 0, w, h);
+        sentBitmap.setPixels(pix, 0, w, 0, 0, w, h);
 
-        return (bitmap);
+        return sentBitmap;
     }
 }

--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/RenderScriptBlurHelper.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/RenderScriptBlurHelper.java
@@ -31,18 +31,11 @@ final class RenderScriptBlurHelper {
      *
      * @param sentBitmap       bitmap to blur
      * @param radius           blur radius
-     * @param canReuseInBitmap true if bitmap must be reused without blur
      * @param context          used by RenderScript, can be null if RenderScript disabled
      * @return blurred bitmap
      */
-    public static Bitmap doBlur(Bitmap sentBitmap, int radius, boolean canReuseInBitmap, Context context) {
-        Bitmap bitmap;
-
-        if (canReuseInBitmap) {
-            bitmap = sentBitmap;
-        } else {
-            bitmap = sentBitmap.copy(sentBitmap.getConfig(), true);
-        }
+    public static Bitmap doBlur(Bitmap sentBitmap, int radius, Context context) {
+        Bitmap bitmap = sentBitmap;
 
         if (bitmap.getConfig() == Bitmap.Config.RGB_565) {
             // RenderScript hates RGB_565 so we convert it to ARGB_8888


### PR DESCRIPTION
In the v3 implementation, the bitmap passed
to the BlurHelper is meant to be manipulated.