### PR TITLE
Fix background position issue when device has physical menu

### DIFF
--- a/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
+++ b/lib/src/main/java/fr/tvbarthel/lib/blurdialogfragment/BlurDialogEngine.java
@@ -23,7 +23,10 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.WindowManager;
@@ -365,10 +368,12 @@ public class BlurDialogEngine {
         int rightOffset = 0;
         final int navBarSize = getNavigationBarOffset();
 
-        if (mHoldingActivity.getResources().getBoolean(R.bool.blur_dialog_has_bottom_navigation_bar)) {
-            bottomOffset = navBarSize;
-        } else {
-            rightOffset = navBarSize;
+        if (hasNavigationBar()) {
+            if (mHoldingActivity.getResources().getBoolean(R.bool.blur_dialog_has_bottom_navigation_bar)) {
+                bottomOffset = navBarSize;
+            } else {
+                rightOffset = navBarSize;
+            }
         }
 
         //add offset to the source boundaries since we don't want to blur actionBar pixels
@@ -442,6 +447,13 @@ public class BlurDialogEngine {
         mBlurredBackgroundView = new ImageView(mHoldingActivity);
         mBlurredBackgroundView.setScaleType(ImageView.ScaleType.CENTER_CROP);
         mBlurredBackgroundView.setImageDrawable(new BitmapDrawable(mHoldingActivity.getResources(), overlay));
+    }
+
+    private boolean hasNavigationBar() {
+        boolean hasMenuKey = ViewConfiguration.get(mHoldingActivity).hasPermanentMenuKey();
+        boolean hasBackKey = KeyCharacterMap.deviceHasKey(KeyEvent.KEYCODE_BACK);
+
+        return !hasMenuKey && !hasBackKey;
     }
 
     /**


### PR DESCRIPTION
I've tested the sample app in some samsung devices (specially Samsung S5) with physical menu and the blur effect seems displaced and amplified as some developers noticed, but the same sample with other devices without physical menu seems correct.

The image below illustrate the bug:

![rsz_before](https://cloud.githubusercontent.com/assets/1013076/26007554/5f8f7f64-3717-11e7-8c7a-dc5324a68062.png)

And the fixed version with the code of this PR:

![rsz_after](https://cloud.githubusercontent.com/assets/1013076/26007580/88bc4782-3717-11e7-919e-d13b08cedc9c.png)

Thanks for this great library.
